### PR TITLE
Generalises and streamlines discussion of budgets in MITgcm

### DIFF
--- a/05 Numerical models/MITgcm/Closing-a-carbon-budget-in-BSOSE.md
+++ b/05 Numerical models/MITgcm/Closing-a-carbon-budget-in-BSOSE.md
@@ -1,16 +1,22 @@
-# Closing budgets
+# Closing budgets in MITgcm
+*Contributors*: [Iris Liang](https://github.com/xliang576)
 
 ## What is "closing a budget" and why use budgets
-A lot of processes are programmed and calculated inside the model. When the model runs, they collectively update the model state (temperature, nutrients, dic concentration, etc.). How to restore the contribution of each processes? That is what budgets do. "Closing a budget" means attributing the changes of some model states to the known/coded processes responsible as time proceeds, within a neglectable residual range. In the end, we will be able to get a time series data showing how each processes act on the model domain. 
+A lot of processes are programmed and calculated inside the model. When the model runs, they collectively update the model state (temperature, nutrients, dic concentration, etc.). How to restore the contribution of each processes? That is what budgets do. "Closing a budget" means attributing the changes of some model states to the known/coded processes responsible as time proceeds, within a neglectable residual range. In the end, we will be able to get a time series showing how each process acts on the tracer field. 
 
-To help build the budgets and do analysis, the modellers store and output diagnostics. (See a full list of available [BSOSE diagnostics here](https://sose.ucsd.edu/SO6/ITER155/available_diagnostics.log)) These are additional calculated variables  when the model runs. In this way the ocean states and processes are computationally consistent - an advantage over observations. The "Snapshots" diagnostics are snapshots at the end of 5-day/month, while others are time-averaged over the time period of 5-day/month.
+To help build the budgets and do analysis, we store and output [diagnostics](https://mitgcm.readthedocs.io/en/latest/outp_pkgs/outp_pkgs.html). These are additional calculated variables derived as the model runs. In this way the ocean state and processes are computationally consistent - an advantage over observations.
 
-In this page the property focused on is dissolved inorganic carbon(DIC). 
-Since BSOSE uses data assimilation by reversingly adjusting boundary conditions (without adding or removing unsourced properties), 
-all the budgets *should* be able to close, unless tricky things happen when the model diagnostics are generated or stored. Intricacies also arise from free surface and vertical coordinates.
-Here are [some BSOSE biogeochemical budget examples](https://sose.ucsd.edu/budgets/).
+## Links and resources
+- Documentation (from 2014) on heat and salt budgets (with linear free surface and virtual freshwater flux): [link](https://mitgcm.org/download/daily_snapshot/MITgcm/doc/Heat_Salt_Budget_MITgcm.pdf)
+    - The above documentation arose from a discussion on the MITgcm-support email thread: [link to start of discussion](http://mailman.mitgcm.org/pipermail/mitgcm-support/2014-November/009586.html) (click through "Next message" to follow discussion)
+- Documentation (from 2017) on general budgets (with nonlinear free surface and real freshwater fluxes) with specific example for ECCOv4r3: [link](https://dspace.mit.edu/handle/1721.1/111094)
 
-## DIC transport equation
+## Closing the carbon budget in B-SOSE
+Since BSOSE uses data assimilation by reversingly adjusting boundary conditions (without adding or removing unsourced properties), all the budgets *should* be able to close, unless tricky things happen when the model diagnostics are generated or stored. Intricacies also arise from free surface and vertical coordinates. Here are [some BSOSE biogeochemical budget examples](https://sose.ucsd.edu/budgets/).
+
+Lists of available diagnostics are available for most of the BSOSE iterations, e.g. for [ITER155](https://sose.ucsd.edu/SO6/ITER155/available_diagnostics.log). The "snapshots" diagnostics are snapshots at the end of 5-day/month, while others are time-averaged over the time period of 5-day/month.
+
+### DIC transport equation
 Tracer conservation equation is 
 ```math
 \frac{\partial DIC}{\partial t} = - \vec{u} \cdot \nabla DIC + \gamma \nabla^2 DIC + \mathcal{F_a} + Bio
@@ -22,7 +28,7 @@ Written in Budget term is
 TEND =ADV + DIFF + SURF + BIO
 ```
 
-## Terms in tracer budget
+### Terms in tracer budget
 LHS $`TEND`$ is the time difference of concentration `TRAC01`, namely
 ```math 
 \frac{DIC(t_{n+1}) - DIC(t_n)}{\Delta t} 
@@ -34,8 +40,6 @@ LHS $`TEND`$ is the time difference of concentration `TRAC01`, namely
 ```
 where $`h`$ is sea surface height anomaly (diagnostics`ETAN`), $`H`$ is ocean depth. (?)]
 
-
-
 The corresponding process and diagnostics for RHS are given in the following table.
 
 |   Term	|   Process	|   Diagnostics	|  
@@ -45,13 +49,6 @@ The corresponding process and diagnostics for RHS are given in the following tab
 |   SURF	|   Surface sea-air carbon flux	|   `BLGCFLX`	|   
 |   BIO	|   Biological source and sinks	|   `BLGBIOC`	|   
 
-## Example code
+### Example code
 
-See repository xxx. 
-
-## Help on other budgets and budget analysis
-Guideline on heat, salinity and other budget (in MITgcm) can be found [here](https://mitgcm.org/download/daily_snapshot/MITgcm/doc/Heat_Salt_Budget_MITgcm.pdf),
-[here](https://www.ecco-group.org/docs/evaluating_budgets_in_eccov4r3_updated_20220118.pdf), 
-and (in MOM6) [here](https://mom6-analysiscookbook.readthedocs.io/en/latest/notebooks/Closing_tracer_budgets.html).
-
-Some analysis on BSOSE budget can be found [here](https://github.com/gmacgilchrist/bsose/tree/main).
+🚧 Under construction 🚧


### PR DESCRIPTION
Makes some edits to @xliang576 's budget description, making it general for MITgcm, and using BSOSE DIC as an  example.. Ultimately, I would like to see separate worked examples of carbon, heat, and salt budgets in notebooks, in which case this page would just serve as a landing page for links and resources.